### PR TITLE
Added a db constraint so that users cant create reservations in the past

### DIFF
--- a/templates/emails/reservation_confirmed.html
+++ b/templates/emails/reservation_confirmed.html
@@ -1,0 +1,9 @@
+<p>Hi {{ user.first_name|default:username }},</p>
+<p><strong>Good news — your reservation #{{ reservation.pk }} has been confirmed!</strong></p>
+<ul>
+  <li><strong>Vehicle:</strong> {{ reservation.vehicle }}</li>
+  <li><strong>Pickup:</strong> {{ reservation.pickup_location }} on {{ reservation.start_date }}</li>
+  <li><strong>Return:</strong> {{ reservation.return_location }} on {{ reservation.end_date }}</li>
+  <li><strong>Total price:</strong> {{ reservation.total_price }} {{ reservation.currency|default:"EUR" }}</li>
+</ul>
+<p>Thanks,<br>The Team</p>

--- a/templates/emails/reservation_confirmed.txt
+++ b/templates/emails/reservation_confirmed.txt
@@ -1,0 +1,11 @@
+Hi {{ user.first_name|default:username }},
+
+Good news — your reservation #{{ reservation.pk }} has been confirmed!
+
+Vehicle: {{ reservation.vehicle }}
+Pickup: {{ reservation.pickup_location }} on {{ reservation.start_date }}
+Return: {{ reservation.return_location }} on {{ reservation.end_date }}
+Total price: {{ reservation.total_price }} {{ reservation.currency|default:"EUR" }}
+
+Thanks,
+The Team

--- a/templates/emails/reservation_rejected.html
+++ b/templates/emails/reservation_rejected.html
@@ -1,0 +1,4 @@
+<p>Hi {{ user.first_name|default:username }},</p>
+<p><strong>We’re sorry — your reservation #{{ reservation.pk }} has been rejected.</strong></p>
+<p>If you have questions, reply to this message.</p>
+<p>Thanks,<br>The Team</p>

--- a/templates/emails/reservation_rejected.txt
+++ b/templates/emails/reservation_rejected.txt
@@ -1,0 +1,8 @@
+Hi {{ user.first_name|default:username }},
+
+We’re sorry — your reservation #{{ reservation.pk }} has been rejected.
+
+If you have questions, reply to this message.
+
+Thanks,
+The Team

--- a/templates/emails/reservation_status_changed.html
+++ b/templates/emails/reservation_status_changed.html
@@ -1,0 +1,13 @@
+<p>Hi {{ user.first_name|default:username }},</p>
+<p>
+  The status of your reservation <strong>#{{ reservation.pk }}</strong> has changed
+  from “{{ old_status|title }}” to <strong>{{ new_status|title }}</strong>.
+</p>
+<ul>
+  <li><strong>Vehicle:</strong> {{ reservation.vehicle }}</li>
+  <li><strong>Pickup:</strong> {{ reservation.pickup_location }} on {{ reservation.start_date }}</li>
+  <li><strong>Return:</strong> {{ reservation.return_location }} on {{ reservation.end_date }}</li>
+  <li><strong>Total price:</strong> {{ reservation.total_price }} {{ reservation.currency|default:"EUR" }}</li>
+</ul>
+<p>You can view your reservation from your account.</p>
+<p>Thanks,<br>The Team</p>

--- a/templates/emails/reservation_status_changed.txt
+++ b/templates/emails/reservation_status_changed.txt
@@ -1,0 +1,14 @@
+Hi {{ user.first_name|default:username }},
+
+The status of your reservation #{{ reservation.pk }} has changed
+from "{{ old_status|title }}" to "{{ new_status|title }}".
+
+Vehicle: {{ reservation.vehicle }}
+Pickup: {{ reservation.pickup_location }} on {{ reservation.start_date }}
+Return: {{ reservation.return_location }} on {{ reservation.end_date }}
+Total price: {{ reservation.total_price }} {{ reservation.currency|default:"EUR" }}
+
+You can view your reservation from your account.
+
+Thanks,
+The Team


### PR DESCRIPTION
Added logic in the clean function of the Reservation model, so that users can't set pick up / drop off dates in the past when reserving a vehicle.

Another planned commit for this issue is ongoing - limiting the search with the same logic, the user shouldn't be able to search for vehicles with pick up / drop off dates in the past.