### PR TITLE
Improving the logic behind editing reservations

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -194,7 +194,10 @@ class AdminOnlyAdmin(admin.ModelAdmin):
 
     def has_view_permission(self, request, obj=None):
         # Managers need read-only access for autocomplete
-        return request.user.is_authenticated and request.user.role in ["admin", "manager"]
+        return request.user.is_authenticated and request.user.role in [
+            "admin",
+            "manager",
+        ]
 
     def has_add_permission(self, request):
         return request.user.is_authenticated and request.user.role == "admin"

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -48,7 +48,7 @@ urlpatterns = [
         name="reservation-update",
     ),
     # User's own reservations
-    path("my-reservations/", views.user_reservations, name="user-reservations"),
+    path("reservations/", views.user_reservations, name="user-reservations"),
     # Manager convenience routes (if you want a separate manager namespace)
     path(
         "manager/reservations/", views.manager_reservations, name="manager-reservations"

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -64,7 +64,7 @@ def login_view(request):
             elif user.role == "manager":
                 return redirect("accounts:manager-dashboard")
             else:
-                return redirect("accounts:user-reservations")
+                return redirect("/")
         else:
             messages.error(request, "Invalid username or password.")
     else:

--- a/inventory/helpers/redirect_back_to_search.py
+++ b/inventory/helpers/redirect_back_to_search.py
@@ -1,7 +1,7 @@
 from django.shortcuts import redirect
 
 
-def _redirect_back_to_search(start_str: str | None, end_str: str | None):
+def redirect_back_to_search(start_str: str | None, end_str: str | None):
     start_q = start_str or ""
     end_q = end_str or ""
     return redirect(f"/search/?start={start_q}&end={end_q}")

--- a/inventory/helpers/signals.py
+++ b/inventory/helpers/signals.py
@@ -22,7 +22,9 @@ def _capture_old_status(sender, instance: Reservation, **kwargs):
 
 
 @receiver(post_save, sender=Reservation)
-def _notify_on_create_or_transition(sender, instance: Reservation, created: bool, **kwargs):
+def _notify_on_create_or_transition(
+    sender, instance: Reservation, created: bool, **kwargs
+):
     if created:
         transaction.on_commit(lambda: send_reservation_created_email(instance))
         return
@@ -32,5 +34,7 @@ def _notify_on_create_or_transition(sender, instance: Reservation, created: bool
         return
 
     transaction.on_commit(
-        lambda: send_reservation_status_changed_email(instance, old_status, instance.status)
+        lambda: send_reservation_status_changed_email(
+            instance, old_status, instance.status
+        )
     )

--- a/inventory/views/reservations.py
+++ b/inventory/views/reservations.py
@@ -7,10 +7,11 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_http_methods
 
 from inventory.helpers.parse_iso_date import parse_iso_date
-from inventory.helpers.redirect_back_to_search import _redirect_back_to_search
+from inventory.helpers.redirect_back_to_search import redirect_back_to_search
 from inventory.models.cart import ReservationGroup
-from inventory.models.reservation import Location, Reservation, ReservationStatus
+from inventory.models.reservation import Location, Reservation, ReservationStatus, BLOCKING_STATUSES
 from inventory.models.vehicle import Vehicle
+from django.utils import timezone
 
 
 class ReservationEditForm(forms.ModelForm):
@@ -40,7 +41,7 @@ def reserve(request):
 
     if start_date is None or end_date is None or end_date <= start_date:
         messages.error(request, "Start date must be before end date.")
-        return _redirect_back_to_search(form_data.get("start"), form_data.get("end"))
+        return redirect_back_to_search(form_data.get("start"), form_data.get("end"))
 
     if form_data.get("pickup_location"):
         pickup_location = get_object_or_404(
@@ -60,19 +61,19 @@ def reserve(request):
         messages.error(
             request, "This vehicle has no configured pickup/return locations."
         )
-        return _redirect_back_to_search(form_data.get("start"), form_data.get("end"))
+        return redirect_back_to_search(form_data.get("start"), form_data.get("end"))
 
     if not vehicle.available_pickup_locations.filter(pk=pickup_location.pk).exists():
         messages.error(
             request, "Selected pickup location is not available for this vehicle."
         )
-        return _redirect_back_to_search(form_data.get("start"), form_data.get("end"))
+        return redirect_back_to_search(form_data.get("start"), form_data.get("end"))
 
     if not vehicle.available_return_locations.filter(pk=return_location.pk).exists():
         messages.error(
             request, "Selected return location is not available for this vehicle."
         )
-        return _redirect_back_to_search(form_data.get("start"), form_data.get("end"))
+        return redirect_back_to_search(form_data.get("start"), form_data.get("end"))
 
     reservation = Reservation(
         user=request.user,
@@ -89,7 +90,7 @@ def reserve(request):
         reservation.save()
     except Exception as exc:
         messages.error(request, str(exc))
-        return _redirect_back_to_search(form_data.get("start"), form_data.get("end"))
+        return redirect_back_to_search(form_data.get("start"), form_data.get("end"))
 
     messages.success(request, "Reservation created.")
     return redirect("inventory:reservations")
@@ -144,6 +145,12 @@ def my_reservations(request):
 
 @login_required
 def edit_reservation(request, pk):
+    """
+    Allow a user to edit their reservation. If the user changes pickup/return dates,
+    we check whether the selected vehicle is available for those dates (ignoring the
+    current reservation itself). If available, we save the new dates and set status
+    back to PENDING for re-approval.
+    """
     reservation = get_object_or_404(
         Reservation.objects.select_related("vehicle", "group"),
         pk=pk,
@@ -152,45 +159,102 @@ def edit_reservation(request, pk):
 
     if request.method == "POST":
         form = ReservationEditForm(request.POST, instance=reservation)
+
         if form.is_valid():
-            selected_vehicle = form.cleaned_data["vehicle"]
-            selected_pickup = form.cleaned_data["pickup_location"]
-            selected_return = form.cleaned_data["return_location"]
+            selected_vehicle = form.cleaned_data.get("vehicle")
+            selected_pickup = form.cleaned_data.get("pickup_location")
+            selected_return = form.cleaned_data.get("return_location")
+            new_start = form.cleaned_data.get("start_date")
+            new_end = form.cleaned_data.get("end_date")
 
-            if selected_pickup and selected_vehicle.available_pickup_locations.exists():
-                if not selected_vehicle.available_pickup_locations.filter(
-                    pk=selected_pickup.pk
-                ).exists():
-                    form.add_error(
-                        "pickup_location",
-                        "Pickup location not allowed for this vehicle.",
+            original_start = reservation.start_date
+            original_end = reservation.end_date
+
+            if not new_start or not new_end:
+                form.add_error(None, "Please provide both pickup and return dates.")
+            else:
+                if new_start >= new_end:
+                    form.add_error("end_date", "End date must be after start date.")
+
+                today = timezone.localdate()
+                if new_start < today:
+                    form.add_error("start_date", "Pickup date cannot be in the past.")
+                if new_end < today:
+                    form.add_error("end_date", "Return date cannot be in the past.")
+
+            if selected_vehicle and selected_pickup and selected_vehicle.available_pickup_locations.exists():
+                if not selected_vehicle.available_pickup_locations.filter(pk=selected_pickup.pk).exists():
+                    form.add_error("pickup_location", "Pickup location not allowed for this vehicle.")
+
+            if selected_vehicle and selected_return and selected_vehicle.available_return_locations.exists():
+                if not selected_vehicle.available_return_locations.filter(pk=selected_return.pk).exists():
+                    form.add_error("return_location", "Return location not allowed for this vehicle.")
+
+            if form.errors:
+                return render(
+                    request,
+                    "inventory/edit_reservation.html",
+                    {
+                        "form": form,
+                        "reservation": reservation,
+                        "vehicles": Vehicle.objects.all().order_by("name"),
+                        "locations": Location.objects.all().order_by("name"),
+                    },
+                )
+
+            overlaps = Reservation.objects.filter(
+                vehicle_id=selected_vehicle.pk,
+                status__in=BLOCKING_STATUSES,
+                start_date__lt=new_end,
+                end_date__gt=new_start,
+            ).exclude(pk=reservation.pk)
+
+            if overlaps.exists():
+                form.add_error(
+                    "start_date",
+                    "This vehicle is not available in the selected period.",
+                )
+                return render(
+                    request,
+                    "inventory/edit_reservation.html",
+                    {
+                        "form": form,
+                        "reservation": reservation,
+                        "vehicles": Vehicle.objects.all().order_by("name"),
+                        "locations": Location.objects.all().order_by("name"),
+                    },
+                )
+
+            try:
+                with transaction.atomic():
+                    instance = form.save(commit=False)
+                    instance.full_clean()
+                    instance.save()
+
+                    dates_changed = (
+                            ("start_date" in form.changed_data) or ("end_date" in form.changed_data)
+                            or original_start != new_start
+                            or original_end != new_end
                     )
 
-            if selected_return and selected_vehicle.available_return_locations.exists():
-                if not selected_vehicle.available_return_locations.filter(
-                    pk=selected_return.pk
-                ).exists():
-                    form.add_error(
-                        "return_location",
-                        "Return location not allowed for this vehicle.",
-                    )
+                    if dates_changed:
+                        instance.status = ReservationStatus.PENDING
+                        instance.save(update_fields=["status"])  # triggers your status-change signal
 
-            if form.is_valid():
-                try:
-                    with transaction.atomic():
-                        instance = form.save(commit=False)
-                        instance.full_clean()
-                        instance.save()
-                    messages.success(request, "Reservation updated.")
-                    return redirect("inventory:reservations")
-                except Exception as exc:
-                    form.add_error(None, str(exc))
+                messages.success(
+                    request,
+                    "Reservation updated." + (" Status set to PENDING for re-approval." if dates_changed else "")
+                )
+                return redirect("inventory:reservations")
+
+            except Exception as exc:
+                form.add_error(None, str(exc))
+
     else:
         form = ReservationEditForm(instance=reservation)
 
     vehicles = Vehicle.objects.all().order_by("name")
     locations = Location.objects.all().order_by("name")
-
     return render(
         request,
         "inventory/edit_reservation.html",
@@ -201,6 +265,7 @@ def edit_reservation(request, pk):
             "locations": locations,
         },
     )
+
 
 
 @login_required


### PR DESCRIPTION
Rewrote the whole logic behind editing the reservation so that when a user edits a reservation the app checks to see if the vehicle is available for the newly selected dates (without counting the reservation of the user editing) and if so, edits the reservation and changes the status back to PENDING if it was RESERVED before, if status was PENDING before editing it stays the same after.