### PR TITLE
hardening cart, validation, and payments

### DIFF
--- a/mockpay/models.py
+++ b/mockpay/models.py
@@ -21,6 +21,11 @@ class PaymentIntent(models.Model):
     reservation_group = models.ForeignKey(
         ReservationGroup, on_delete=models.PROTECT, related_name="payment_intents"
     )
+
+    idempotency_key = models.CharField(
+        max_length=64, unique=True, null=True, blank=True, db_index=True
+    )
+
     amount = models.PositiveIntegerField(
         help_text="Amount in the smallest currency unit (e.g. cents)"
     )

--- a/mockpay/urls.py
+++ b/mockpay/urls.py
@@ -1,15 +1,15 @@
 from django.urls import path
-from . import views
+from .views import checkout_page, checkout_success, result
 
 app_name = "mockpay"
 
 urlpatterns = [
-    path("checkout/<str:client_secret>/", views.checkout_page, name="checkout_page"),
-    path("result/<str:client_secret>/", views.result, name="result"),
-    path("pay/<str:client_secret>/", views.checkout_page, name="checkout_page"),
+    path("checkout/<str:client_secret>/", checkout_page, name="checkout_page"),
+    path("result/<str:client_secret>/", result, name="result"),
+    path("pay/<str:client_secret>/", checkout_page, name="checkout_page"),
     path(
         "pay/<str:client_secret>/success/",
-        views.checkout_success,
+        checkout_success,
         name="checkout_success",
     ),
 ]


### PR DESCRIPTION
I fixed Cart.clear() with transactional row locks, enforced end_date > start_date plus a configurable MAX_RENTAL_DAYS, and made pickup/return locations mandatory. Cart items now cascade-delete if their location is removed. Add-to-cart is CSRF-protected and rejects missing/invalid locations. Payment confirmation is idempotent and transactional (locks the intent, rechecks expiry/state), and I added routing fixes plus the missing result/checkout_success views.