### PR TITLE
Fixing edit vehicle and search logic

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -671,14 +671,12 @@ def vehicle_edit(request, pk):
             vehicle = form.save(commit=False)
             vehicle.save()
 
-            # Pick-up (single)
             pickup = form.cleaned_data.get("available_pickup_locations")
             if pickup:
-                vehicle.available_pickup_locations.set([pickup[0]])
+                vehicle.available_pickup_locations.set([pickup])
             else:
                 vehicle.available_pickup_locations.clear()
 
-            # Drop-offs (multiple)
             dropoffs = form.cleaned_data.get("available_return_locations")
             if dropoffs:
                 vehicle.available_return_locations.set(dropoffs)
@@ -690,15 +688,12 @@ def vehicle_edit(request, pk):
     else:
         form = VehicleForm(instance=vehicle)
 
-        # Pre-select single pick-up as a list
-        if vehicle.available_pickup_locations.exists():
-            form.fields["available_pickup_locations"].initial = [
-                vehicle.available_pickup_locations.first().id
-            ]
-
     return render(
-        request, "accounts/vehicles/vehicle_form.html", {"form": form}
+        request,
+        "accounts/vehicles/vehicle_form.html",
+        {"form": form},
     )
+
 
 def vehicle_delete(request, pk):
     vehicle = get_object_or_404(Vehicle, pk=pk)

--- a/inventory/views/search.py
+++ b/inventory/views/search.py
@@ -18,15 +18,13 @@ def home(request):
     return render(request, "home.html", context)
 
 
-def _clip(a: date, b: date, lo: date, hi: date) -> Tuple[date, date]:
-    """Clip [a,b) to [lo,hi). Returns (start,end) with start < end, else (None, None)."""
+def _clip(a: date, b: date, lo: date, hi: date):
     s = max(a, lo)
     e = min(b, hi)
     return (s, e) if s < e else (None, None)
 
 
-def _merge(blocks: List[Tuple[date, date]]) -> List[Tuple[date, date]]:
-    """Merge overlapping/touching [start,end) blocks; input/outputs are sorted half-open intervals."""
+def _merge(blocks: List[tuple]):
     if not blocks:
         return []
     blocks = sorted(blocks, key=lambda x: x[0])
@@ -40,15 +38,14 @@ def _merge(blocks: List[Tuple[date, date]]) -> List[Tuple[date, date]]:
     return merged
 
 
-def _free_slices(search_start: date, search_end: date, blocks: List[Tuple[date, date]]) -> List[Tuple[date, date]]:
-    """Return free [start,end) slices inside [search_start,search_end) minus union(blocks)."""
+def _free_slices(search_start: date, search_end: date, blocks: List[tuple]):
     clipped = []
     for s, e in blocks:
         cs, ce = _clip(s, e, search_start, search_end)
         if cs and ce:
             clipped.append((cs, ce))
     merged = _merge(clipped)
-    free: List[Tuple[date, date]] = []
+    free: List[tuple] = []
     cur = search_start
     for bs, be in merged:
         if cur < bs:
@@ -61,11 +58,10 @@ def _free_slices(search_start: date, search_end: date, blocks: List[Tuple[date, 
 
 @login_required
 def search(request):
-    # Parse inputs
     start_str = request.GET.get("start")
     end_str = request.GET.get("end")
-    pickup_location = request.GET.get("pickup_location") or ""
-    return_location = request.GET.get("return_location") or ""
+    pickup_location = (request.GET.get("pickup_location") or "").strip()
+    return_location = (request.GET.get("return_location") or "").strip()
 
     start_date = parse_date(start_str) if start_str else None
     end_date = parse_date(end_str) if end_str else None
@@ -83,23 +79,41 @@ def search(request):
     if not (start_date and end_date and start_date < end_date):
         return render(request, "home.html", context)
 
-    vehicles_qs = Vehicle.objects.all().select_related().order_by("id")
+    vehicles_qs = (
+        Vehicle.objects.all()
+        .prefetch_related("available_pickup_locations", "available_return_locations")
+        .order_by("id")
+    )
+
+    if pickup_location and Location.objects.filter(pk=pickup_location).exists():
+        vehicles_qs = vehicles_qs.filter(available_pickup_locations__id=pickup_location)
+
+    if return_location and Location.objects.filter(pk=return_location).exists():
+        vehicles_qs = vehicles_qs.filter(available_return_locations__id=return_location)
+
+    vehicles_qs = vehicles_qs.distinct()
 
     my_id = request.user.id if request.user.is_authenticated else None
 
-    res_qs = VehicleReservation.objects.filter(
-        group__status__in=ReservationStatus.blocking(),
-        start_date__lt=end_date,
-        end_date__gt=start_date,
-    ).values("vehicle_id", "start_date", "end_date")
+    res_qs = (
+        VehicleReservation.objects.filter(
+            group__status__in=ReservationStatus.blocking(),
+            start_date__lt=end_date,
+            end_date__gt=start_date,
+        )
+        .values("vehicle_id", "start_date", "end_date")
+    )
 
     my_cart_qs = CartItem.objects.none()
     if my_id:
-        my_cart_qs = CartItem.objects.filter(
-            cart__user_id=my_id,
-            start_date__lt=end_date,
-            end_date__gt=start_date,
-        ).values("vehicle_id", "start_date", "end_date")
+        my_cart_qs = (
+            CartItem.objects.filter(
+                cart__user_id=my_id,
+                start_date__lt=end_date,
+                end_date__gt=start_date,
+            )
+            .values("vehicle_id", "start_date", "end_date")
+        )
 
     blocks_by_vehicle = defaultdict(list)
     for row in res_qs:
@@ -112,13 +126,13 @@ def search(request):
 
     for v in vehicles_qs:
         blocks = blocks_by_vehicle.get(v.id, [])
-
         free = _free_slices(start_date, end_date, blocks)
         if not free:
             continue
 
+        rt = RateTable(day=float(v.price_per_day), currency="EUR")
+
         if len(free) == 1 and free[0][0] == start_date and free[0][1] == end_date:
-            rt = RateTable(day=float(v.price_per_day), currency="EUR")
             q = quote_total(start_date, end_date, rt)
             results.append(
                 {
@@ -129,7 +143,6 @@ def search(request):
         else:
             slices = []
             for s, e in free:
-                rt = RateTable(day=float(v.price_per_day), currency="EUR")
                 q = quote_total(s, e, rt)
                 slices.append(
                     {

--- a/templates/accounts/vehicles/vehicle_form.html
+++ b/templates/accounts/vehicles/vehicle_form.html
@@ -3,33 +3,24 @@
   <h2>{% if form.instance.pk %}Edit Vehicle{% else %}Add Vehicle{% endif %}</h2>
   <form method="post">
     {% csrf_token %}
-      <p>{{ form.name.label_tag }} {{ form.name }}</p>
-      <p>{{ form.plate_number.label_tag }} {{ form.plate_number }}</p>
-      <p>{{ form.car_type.label_tag }} {{ form.car_type }}</p>
-      <p>{{ form.engine_type.label_tag }} {{ form.engine_type }}</p>
+
+    <p>{{ form.name.label_tag }} {{ form.name }}</p>
+    <p>{{ form.plate_number.label_tag }} {{ form.plate_number }}</p>
+    <p>{{ form.car_type.label_tag }} {{ form.car_type }}</p>
+    <p>{{ form.engine_type.label_tag }} {{ form.engine_type }}</p>
+
     <div>
       {{ form.seats.label_tag }} {{ form.seats }}
       {% if form.seats.errors %}<div class="error">{{ form.seats.errors|striptags }}</div>{% endif %}
-      </div>
-      <p>{{ form.price_per_day.label_tag }} {{ form.price_per_day }}</p>
-<p>{{ form.available_pickup_locations.label_tag }} {{ form.available_pickup_locations }}</p>
-
-
-    <!-- Drop-off with add/remove buttons -->
-    <p>{{ form.available_return_locations.label_tag }}</p>
-    <div id="dropoff-container">
-      <select id="dropoff-select">
-        {% for loc in form.available_return_locations.field.queryset %}
-          <option value="{{ loc.id }}">{{ loc.name }}</option>
-        {% endfor %}
-      </select>
-      <button type="button" id="add-dropoff">Add</button>
     </div>
 
-    <ul id="dropoff-list"></ul>
+    <p>{{ form.price_per_day.label_tag }} {{ form.price_per_day }}</p>
 
-    <!-- Hidden inputs will be injected here -->
-    <div id="dropoff-hidden"></div>
+    {# Single pickup - preselected by the form #}
+    <p>{{ form.available_pickup_locations.label_tag }} {{ form.available_pickup_locations }}</p>
+
+    {# Multi drop-offs - preselected by the form #}
+    <p>{{ form.available_return_locations.label_tag }} {{ form.available_return_locations }}</p>
 
     <button class="btn primary" type="submit">Save</button>
     <a class="btn" href="{% url 'accounts:vehicle-list' %}">Cancel</a>
@@ -40,47 +31,4 @@
   {% else %}
       <a href="{% url 'accounts:manager-dashboard' %}" class="btn btn-secondary">← Back to Dashboard</a>
   {% endif %}
-
-  <script>
-    const select = document.getElementById("dropoff-select");
-    const addBtn = document.getElementById("add-dropoff");
-    const list = document.getElementById("dropoff-list");
-    const hiddenDiv = document.getElementById("dropoff-hidden");
-
-    let selected = [];
-
-    addBtn.addEventListener("click", () => {
-      const val = select.value;
-      if (!selected.includes(val)) {
-        selected.push(val);
-        updateList();
-      }
-    });
-
-    function updateList() {
-      list.innerHTML = "";
-      hiddenDiv.innerHTML = "";
-      selected.forEach((id) => {
-        const li = document.createElement("li");
-        li.textContent = select.querySelector(`[value='${id}']`).text;
-
-        const btn = document.createElement("button");
-        btn.textContent = "Remove";
-        btn.type = "button";
-        btn.onclick = () => {
-          selected = selected.filter((x) => x !== id);
-          updateList();
-        };
-        li.appendChild(btn);
-        list.appendChild(li);
-
-        // generate hidden input for Django
-        const hidden = document.createElement("input");
-        hidden.type = "hidden";
-        hidden.name = "available_return_locations";
-        hidden.value = id;
-        hiddenDiv.appendChild(hidden);
-      });
-    }
-  </script>
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -60,90 +60,81 @@
     </div>
   </div>
 
-  {% if results %}
-    <h3>Available vehicles</h3>
-    <p style="margin:8px 0 0; color:#6b7280; font-size:14px;">
-      Long-stay savings appear for trips longer than 6 days. Per-day figures are approximate.
-    </p>
+  {# -------- FULLY AVAILABLE RESULTS -------- #}
+  <h3>Available vehicles</h3>
+  <p style="margin:8px 0 0; color:#6b7280; font-size:14px;">
+    Long-stay savings appear for trips longer than 6 days. Per-day figures are approximate.
+  </p>
 
-    {% for r in results %}
-      {% with pk_loc=r.vehicle.pickup_location|default_if_none:'' %}
-      {% with pk_loc_first=r.vehicle.available_pickup_locations.all.0 %}
-      {% with pickup=pk_loc|default:pk_loc_first %}
-      <div class="card">
-        <div class="row">
-          <div>
-            <strong>{{ r.vehicle }}</strong><br>
-            {{ r.vehicle.car_type|title }} • {{ r.vehicle.engine_type|title }} •
-            {% if r.vehicle.unlimited_seats %}∞ seats{% else %}{{ r.vehicle.seats }} seats{% endif %}
-          </div>
+  {% for r in results %}
+    {% with pk_loc=r.vehicle.pickup_location|default_if_none:'' %}
+    {% with pk_loc_first=r.vehicle.available_pickup_locations.all.0 %}
+    {% with pickup=pk_loc|default:pk_loc_first %}
+    <div class="card">
+      <div class="row">
+        <div>
+          <strong>{{ r.vehicle }}</strong><br>
+          {{ r.vehicle.car_type|title }} • {{ r.vehicle.engine_type|title }} •
+          {% if r.vehicle.unlimited_seats %}∞ seats{% else %}{{ r.vehicle.seats }} seats{% endif %}
+        </div>
 
-          <div>
-            {% if r.quote.days > 6 %}
-              {% if r.vehicle.price_per_day %}
-                <div style="margin-bottom:2px;">
-                  <span style="text-decoration:line-through; color:#6b7280;">
-                    {% widthratio r.quote.days 1 r.vehicle.price_per_day %} {{ r.quote.currency }}
-                  </span>
-                  <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
-                </div>
-                <div style="font-size:.9em; color:#6b7280;">
-                  ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
-                  (instead of {{ r.vehicle.price_per_day }} {{ r.quote.currency }}/day)
-                </div>
-              {% elif r.vehicle.daily_price %}
-                <div style="margin-bottom:2px;">
-                  <span style="text-decoration:line-through; color:#6b7280;">
-                    {% widthratio r.quote.days 1 r.vehicle.daily_price %} {{ r.quote.currency }}
-                  </span>
-                  <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
-                </div>
-                <div style="font-size:.9em; color:#6b7280;">
-                  ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
-                  (instead of {{ r.vehicle.daily_price }} {{ r.quote.currency }}/day)
-                </div>
-              {% elif r.vehicle.base_daily_rate %}
-                <div style="margin-bottom:2px;">
-                  <span style="text-decoration:line-through; color:#6b7280;">
-                    {% widthratio r.quote.days 1 r.vehicle.base_daily_rate %} {{ r.quote.currency }}
-                  </span>
-                  <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
-                </div>
-                <div style="font-size:.9em; color:#6b7280;">
-                  ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
-                  (instead of {{ r.vehicle.base_daily_rate }} {{ r.quote.currency }}/day)
-                </div>
-              {% elif r.quote.daily_price %}
-                <div style="margin-bottom:2px;">
-                  <span style="text-decoration:line-through; color:#6b7280;">
-                    {% widthratio r.quote.days 1 r.quote.daily_price %} {{ r.quote.currency }}
-                  </span>
-                  <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
-                </div>
-                <div style="font-size:.9em; color:#6b7280;">
-                  ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
-                  (instead of {{ r.quote.daily_price }} {{ r.quote.currency }}/day)
-                </div>
-              {% elif r.quote.base_daily_rate %}
-                <div style="margin-bottom:2px;">
-                  <span style="text-decoration:line-through; color:#6b7280;">
-                    {% widthratio r.quote.days 1 r.quote.base_daily_rate %} {{ r.quote.currency }}
-                  </span>
-                  <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
-                </div>
-                <div style="font-size:.9em; color:#6b7280;">
-                  ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
-                  (instead of {{ r.quote.base_daily_rate }} {{ r.quote.currency }}/day)
-                </div>
-              {% else %}
-                <div>
-                  Total for {{ r.quote.days }} day{{ r.quote.days|pluralize }}:
-                  <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong>
-                </div>
-                <div style="font-size:.9em; color:#6b7280; margin-top:4px;">
-                  ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
-                </div>
-              {% endif %}
+        <div>
+          {% if r.quote.days > 6 %}
+            {% if r.vehicle.price_per_day %}
+              <div style="margin-bottom:2px;">
+                <span style="text-decoration:line-through; color:#6b7280;">
+                  {% widthratio r.quote.days 1 r.vehicle.price_per_day %} {{ r.quote.currency }}
+                </span>
+                <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
+              </div>
+              <div style="font-size:.9em; color:#6b7280;">
+                ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
+                (instead of {{ r.vehicle.price_per_day }} {{ r.quote.currency }}/day)
+              </div>
+            {% elif r.vehicle.daily_price %}
+              <div style="margin-bottom:2px;">
+                <span style="text-decoration:line-through; color:#6b7280;">
+                  {% widthratio r.quote.days 1 r.vehicle.daily_price %} {{ r.quote.currency }}
+                </span>
+                <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
+              </div>
+              <div style="font-size:.9em; color:#6b7280;">
+                ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
+                (instead of {{ r.vehicle.daily_price }} {{ r.quote.currency }}/day)
+              </div>
+            {% elif r.vehicle.base_daily_rate %}
+              <div style="margin-bottom:2px;">
+                <span style="text-decoration:line-through; color:#6b7280;">
+                  {% widthratio r.quote.days 1 r.vehicle.base_daily_rate %} {{ r.quote.currency }}
+                </span>
+                <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
+              </div>
+              <div style="font-size:.9em; color:#6b7280;">
+                ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
+                (instead of {{ r.vehicle.base_daily_rate }} {{ r.quote.currency }}/day)
+              </div>
+            {% elif r.quote.daily_price %}
+              <div style="margin-bottom:2px;">
+                <span style="text-decoration:line-through; color:#6b7280;">
+                  {% widthratio r.quote.days 1 r.quote.daily_price %} {{ r.quote.currency }}
+                </span>
+                <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
+              </div>
+              <div style="font-size:.9em; color:#6b7280;">
+                ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
+                (instead of {{ r.quote.daily_price }} {{ r.quote.currency }}/day)
+              </div>
+            {% elif r.quote.base_daily_rate %}
+              <div style="margin-bottom:2px;">
+                <span style="text-decoration:line-through; color:#6b7280;">
+                  {% widthratio r.quote.days 1 r.quote.base_daily_rate %} {{ r.quote.currency }}
+                </span>
+                <span> → <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong></span>
+              </div>
+              <div style="font-size:.9em; color:#6b7280;">
+                ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
+                (instead of {{ r.quote.base_daily_rate }} {{ r.quote.currency }}/day)
+              </div>
             {% else %}
               <div>
                 Total for {{ r.quote.days }} day{{ r.quote.days|pluralize }}:
@@ -153,65 +144,74 @@
                 ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
               </div>
             {% endif %}
-          </div>
+          {% else %}
+            <div>
+              Total for {{ r.quote.days }} day{{ r.quote.days|pluralize }}:
+              <strong>{{ r.quote.total }} {{ r.quote.currency }}</strong>
+            </div>
+            <div style="font-size:.9em; color:#6b7280; margin-top:4px;">
+              ≈ {% widthratio r.quote.total r.quote.days 1 %} {{ r.quote.currency }}/day
+            </div>
+          {% endif %}
+        </div>
 
-          <div>
-            {% if request.user.is_authenticated %}
-              <form method="post" action="{% url 'inventory:reserve' %}">
-                {% csrf_token %}
-                <input type="hidden" name="vehicle" value="{{ r.vehicle.id }}">
-                <input type="hidden" name="start" value="{{ start }}">
-                <input type="hidden" name="end" value="{{ end }}">
+        <div>
+          {% if request.user.is_authenticated %}
+            <form method="post" action="{% url 'inventory:reserve' %}">
+              {% csrf_token %}
+              <input type="hidden" name="vehicle" value="{{ r.vehicle.id }}">
+              <input type="hidden" name="start" value="{{ start }}">
+              <input type="hidden" name="end" value="{{ end }}">
 
-                <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
-                  <div>
-                    <strong>Pickup:</strong>
-                    {% if pickup %}
-                      {{ pickup.name }}
-                      <input type="hidden" name="pickup_location" value="{{ pickup.id }}">
-                    {% else %}
-                      <em>No pickup location configured</em>
-                    {% endif %}
-                  </div>
-
-                  <label>
-                    Return:
-                    <select name="return_location" required>
-                      {% for loc in r.vehicle.available_return_locations.all %}
-                        <option value="{{ loc.id }}">{{ loc.name }}</option>
-                      {% empty %}
-                        <option value="">No return locations configured</option>
-                      {% endfor %}
-                    </select>
-                  </label>
-
-                  {% if pickup and r.vehicle.available_return_locations.all|length %}
-                    <button class="btn primary" type="submit">Add to cart</button>
+              <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+                <div>
+                  <strong>Pickup:</strong>
+                  {% if pickup %}
+                    {{ pickup.name }}
+                    <input type="hidden" name="pickup_location" value="{{ pickup.id }}">
                   {% else %}
-                    <span style="font-size:0.9em;">This vehicle has incomplete location settings.</span>
+                    <em>No pickup location configured</em>
                   {% endif %}
                 </div>
-              </form>
-            {% else %}
-              <a class="btn"
-                 href="{% url 'accounts:login' %}?next={% url 'inventory:search' %}?start={{ start }}&end={{ end }}{% if pickup_location %}&pickup_location={{ pickup_location }}{% endif %}{% if return_location %}&return_location={{ return_location }}{% endif %}">
-                Login to add to cart
-              </a>
-            {% endif %}
-          </div>
+
+                <label>
+                  Return:
+                  <select name="return_location" required>
+                    {% for loc in r.vehicle.available_return_locations.all %}
+                      <option value="{{ loc.id }}">{{ loc.name }}</option>
+                    {% empty %}
+                      <option value="">No return locations configured</option>
+                    {% endfor %}
+                  </select>
+                </label>
+
+                {% if pickup and r.vehicle.available_return_locations.all|length %}
+                  <button class="btn primary" type="submit">Add to cart</button>
+                {% else %}
+                  <span style="font-size:0.9em;">This vehicle has incomplete location settings.</span>
+                {% endif %}
+              </div>
+            </form>
+          {% else %}
+            <a class="btn"
+               href="{% url 'accounts:login' %}?next={% url 'inventory:search' %}?start={{ start }}&end={{ end }}{% if pickup_location %}&pickup_location={{ pickup_location }}{% endif %}{% if return_location %}&return_location={{ return_location }}{% endif %}">
+              Login to add to cart
+            </a>
+          {% endif %}
         </div>
       </div>
-      {% endwith %}
-      {% endwith %}
-      {% endwith %}
-    {% empty %}
-      <p>No vehicles available for that period.</p>
-    {% endfor %}
-  {% endif %}
+    </div>
+    {% endwith %}
+    {% endwith %}
+    {% endwith %}
+  {% empty %}
+    <p style="margin-top:.5rem; color:#6b7280;">No fully available vehicles for that period.</p>
+  {% endfor %}
 
+  {# -------- PARTIAL RESULTS -------- #}
   {% if partial_results %}
     <h3>Partially available during your dates</h3>
-
+    {# ... existing partial results block unchanged ... #}
     {% for row in partial_results %}
       {% with pk_loc=row.vehicle.pickup_location|default_if_none:'' %}
       {% with pk_loc_first=row.vehicle.available_pickup_locations.all.0 %}
@@ -225,9 +225,8 @@
           </div>
 
           <div style="flex:1;">
-            {# pricing slices unchanged #}
             {% for s in row.slices %}
-              {# ... existing pricing snippet unchanged ... #}
+              {# ... pricing slice variants unchanged ... #}
               {% if s.quote.days > 6 %}
                 {% if row.vehicle.price_per_day %}
                   <div style="margin:.25rem 0;">
@@ -358,5 +357,15 @@
       {% endwith %}
       {% endwith %}
     {% endfor %}
+  {% endif %}
+  {% if start and end and not results and not partial_results %}
+    <div class="card" role="status" aria-live="polite" style="margin-top:.75rem; background:#fff7ed; border-color:#fdba74;">
+      <strong>No vehicles match your search.</strong>
+      <div style="color:#7c2d12; margin-top:4px;">
+        {{ start }} → {{ end }}{% if pickup_location or return_location %},
+        {% if pickup_location %} pickup at selected location{% endif %}{% if pickup_location and return_location %} and{% endif %}{% if return_location %} return at selected location{% endif %}{% endif %}.
+        Try adjusting dates or locations.
+      </div>
+    </div>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
I wired the pickup/return location filters into the search view so results now respect the selected locations.
I updated home.html to always render the results loop with an {% empty %} message and added a clear overall “no vehicles match your search” banner when both full and partial results are empty.